### PR TITLE
Fix latex rendering in markdown

### DIFF
--- a/standalone_algorithms/complementary_filter/README.md
+++ b/standalone_algorithms/complementary_filter/README.md
@@ -11,14 +11,14 @@ The basic complementary filter is shown in a picture below.
 <img src="../illustrations/complementary_filter.png"
      alt="Markdown Monster icon"/>
 
-Where z is an input signal, x and y are noisy measurements of this signal. <img src="https://latex.codecogs.com/svg.image?\hat{z}&space;\:&space;is" title="\hat{z} \: is" /> an estimation of the output signal produced buy the filter. Assume that
+Where z is an input signal, x and y are noisy measurements of this signal. <img src="https://render.githubusercontent.com/render/math?math=\hat{z}%20\:%20is" title="\hat{z} \: is" /> an estimation of the output signal produced buy the filter. Assume that
 the noise in y is mostly high frequency, and the noise in x is mostly low frequency. Then G(s) can be made a low-pass filter to filter out the high-frequency noise in y. If G(s) is low-pass, [1 - G(s)] is the complement, i.e., a high-pass filter which filters out the low-frequency noise in x. The complementary filter can be reconfigured as in figure B. In this case the input to G(s) is
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?y&space;-&space;x&space;=&space;n_2&space;-&space;n_1&space;\:&space;," title="y - x = n_2 - n_1 \: ," /> 
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=y%20-%20x%20=%20n_2%20-%20n_1%20\:%20," title="y - x = n_2 - n_1 \: ," /> 
  
  so that the filter G(s) just operates on the noise or error in the measurements x and y. In the case of noise less or error-free measurements
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{z}&space;=&space;z[1&space;-&space;G(s)]&space;&plus;&space;zG(s)&space;=&space;z," title="\hat{z} = z[1 - G(s)] + zG(s) = z," />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{z}%20=%20z[1%20-%20G(s)]%20%2b%20zG(s)%20=%20z," title="\hat{z} = z[1 - G(s)] + zG(s) = z," />
 
 
 i.e., the signal is estimated perfectly.
@@ -29,7 +29,7 @@ In case if the measurements from different sources give precise information in d
 
 [//]: # "angle = alpha * (angle + gyrData * dt) + beta * accData + gamma * magnData)"
 
-<p align="center"><img alt="angle = \alpha -10\mu \log \frac{d}{d_0} + w " src="https://latex.codecogs.com/svg.image?\phi&space;=&space;\alpha&space;*&space;(\phi&space;&plus;&space;gyrData&space;*&space;dt)&space;&plus;&space;\beta&space;*&space;accData&space;&plus;&space;\gamma&space;*&space;magnData" title="\phi = \alpha * (\phi + gyrData * dt) + \beta * accData + \gamma * magnData" /></p>
+<p align="center"><img alt="angle = \alpha -10\mu \log \frac{d}{d_0} + w " src="https://render.githubusercontent.com/render/math?math=\phi%20=%20\alpha%20*%20(\phi%20%2b%20gyrData%20*%20dt)%20%2b%20\beta%20*%20accData%20%2b%20\gamma%20*%20magnData" title="\phi = \alpha * (\phi + gyrData * dt) + \beta * accData + \gamma * magnData" /></p>
 
 where alpha, beta, gamma are constant weights of different measurement sources.
 
@@ -40,29 +40,29 @@ Transfer function of low-pass filter
 
 [//]: # "https://en.wikipedia.org/wiki/Low-pass_filter"
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?H(s)&space;=&space;\frac{\omega_0}{s&space;&plus;&space;\omega_0}" title="H(s) = \frac{\omega_0}{s + \omega_0}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=H(s)%20=%20\frac{\omega_0}{s%20%2b%20\omega_0}" title="H(s) = \frac{\omega_0}{s + \omega_0}" />
 
-where <img src="https://latex.codecogs.com/svg.image?\omega_0" title="\omega_0" /> is a cutoff frequency of a filter
+where <img src="https://render.githubusercontent.com/render/math?math=\omega_0" title="\omega_0" /> is a cutoff frequency of a filter
 
 Low-pass filter is the complement of a high-pass filter. High-pass filter is a filter that passes signals with a frequency higher than a certain cutoff frequency.
 Transffer function of high-pass filter
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?H(s)&space;=&space;\frac{s}{s&space;&plus;&space;\omega_0}" title="H(s) = \frac{s}{s + \omega_0}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=H(s)%20=%20\frac{s}{s%20%2b%20\omega_0}" title="H(s) = \frac{s}{s + \omega_0}" />
 
 Consider a first-order integrator
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\dot{x}&space;=&space;u" title="\dot{x} = u" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\dot{x}%20=%20u" title="\dot{x} = u" />
 
 with the folowing measurement characteristics
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?y_x&space;=&space;L(s)x&space;&plus;&space;\mu_x,&space;y_u&space;=&space;u&space;&plus;&space;\mu_u&space;&plus;&space;b(t)" title="y_x = L(s)x + \mu_x, y_u = u + \mu_u + b(t)" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=y_x%20=%20L(s)x%20%2b%20\mu_x,%20y_u%20=%20u%20%2b%20\mu_u%20%2b%20b(t)" title="y_x = L(s)x + \mu_x, y_u = u + \mu_u + b(t)" />
 
-Measurements <img src="https://latex.codecogs.com/svg.image?y_x&space;\hspace{1mm}&space;and&space;\hspace{1mm}&space;y_u" title="y_x \hspace{1mm} and \hspace{1mm} y_u" /> can be fused into an estimate <img src="https://latex.codecogs.com/svg.image?x_{est}" title="x_{est}" /> of a state <img src="https://latex.codecogs.com/svg.image?x" title="x" /> via the filter
+Measurements <img src="https://render.githubusercontent.com/render/math?math=y_x%20\hspace{1mm}%20and%20\hspace{1mm}%20y_u" title="y_x \hspace{1mm} and \hspace{1mm} y_u" /> can be fused into an estimate <img src="https://render.githubusercontent.com/render/math?math=x_{est}" title="x_{est}" /> of a state <img src="https://render.githubusercontent.com/render/math?math=x" title="x" /> via the filter
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?x_{est}&space;=&space;F_1(s)y_x&space;&plus;&space;F_2(s)\frac{y_u}{s}" title="x_{est} = F_1(s)y_x + F_2(s)\frac{y_u}{s}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=x_{est}%20=%20F_1(s)y_x%20%2b%20F_2(s)\frac{y_u}{s}" title="x_{est} = F_1(s)y_x + F_2(s)\frac{y_u}{s}" />
 
 A filter is called a complementary filter if 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?F_1(s)&space;&plus;&space;F_2(s)&space;=&space;1" title="F_1(s) + F_2(s) = 1" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=F_1(s)%20%2b%20F_2(s)%20=%201" title="F_1(s) + F_2(s) = 1" />
 
 ### Comparison with Kalman filter
 
@@ -72,47 +72,49 @@ Complementary filter outperforms Kalman filter significantly by using less compu
 
 Acceleration is stored in quaternion form. The weight part of it is a numeric value of the acceleration, the vector part -- vector components.
 
-The goal of developing an estimator is to provide a smooth estimate <img src="https://latex.codecogs.com/svg.image?\hat{R(t)}&space;\in&space;SO(3)" title="\hat{R(t)} \in SO(3)" /> of a state R(t) that is evolving due
+The goal of developing an estimator is to provide a smooth estimate <img src="https://render.githubusercontent.com/render/math?math=\hat{R(t)}%20\in%20SO(3)" title="\hat{R(t)} \in SO(3)" /> of a state R(t) that is evolving due
 to some external input based on a set of measurements.
 
 Frame of reference allows to determine the error. It can be calculated as follows
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\dot{\hat{R}}&space;=&space;R^{*}&space;*&space;R" title="\dot{\hat{R}} = R^{*} * R" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\dot{\hat{R}}%20=%20R^{*}%20*%20R" title="\dot{\hat{R}} = R^{*} * R" />
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?err&space;=&space;acc&space;\times&space;\dot{\hat{R}" title="err = acc \times \dot{\hat{R}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=err%20=%20acc%20\times%20\dot{\hat{R}}" title="err = acc \times \dot{\hat{R}}" />
 
 The direct complementary ﬁlter dynamics are speciﬁed by
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\dot{\hat{R}}&space;=&space;(R\Omega&space;*&space;R\omega)\times&space;\hat{R}" title="\dot{\hat{R}} = (R\Omega * R\omega)\times \hat{R}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\dot{\hat{R}}%20=%20(R\Omega%20*%20R\omega)\times%20\hat{R}" title="\dot{\hat{R}} = (R\Omega * R\omega)\times \hat{R}" />
 
 The R* operation is an inverse operation on SO(3)
 
 The kinematics can be written directly in terms of the quaternion representation of SO(3) by
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\dot{q}&space;=&space;q&space;\times&space;p(\Omega)" title="\dot{q} = q \times p(\Omega)" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\dot{q}%20=%20q%20\times%20p(\Omega)" title="\dot{q} = q \times p(\Omega)" />
 
-Quaternion is multiplied by the pure rotation quaternion <img src="https://latex.codecogs.com/svg.image?p(\Omega)" title="p(\Omega)" />, where real part is equal to zero.
+Quaternion is multiplied by the pure rotation quaternion <img src="https://render.githubusercontent.com/render/math?math=p(\Omega)" title="p(\Omega)" />, where real part is equal to zero.
 In the source code provided 'updateQuaternion(mQ, rotation)' function which does the same calculations.
 
 The gyroscope data is integrated every timestep with the current angle value:
 
-`omega = gyro * dt + mIntegralError * dt;`
+```cpp
+omega = gyro * dt + mIntegralError * dt;
+```
 
 ### Components
 
 The following constant coefficients are the weights applied to accelerometer, gyroscope and magnetometer components.
 
-```
-    double     mKaccelerometer;
-    double     mKmagnetometer;
-    double     mKintegralGain;
+```cpp
+double     mKaccelerometer;
+double     mKmagnetometer;
+double     mKintegralGain;
 ```
 
 ### Build
 
 To build the project for running tests make sure that `BUILD_TESTS` option is turned on.
 
-```
+```sh
 cd /standalone_algorithms/complementary_filter
 cmake -Bbuild -H.
 cmake --build build
@@ -120,7 +122,7 @@ cmake --build build
 
 Run tests:
 
-```
+```sh
 ./build/test-filter
 ```
 

--- a/standalone_algorithms/pedometer/README.md
+++ b/standalone_algorithms/pedometer/README.md
@@ -21,7 +21,7 @@ To build the project for running tests make sure that `BUILD_TESTS` option in CM
 
 To build the project for running example turn `BUILD_EXAMPLES` on.
 
-```
+```sh
 cd /standalone_algorithms/pedometer && rm -rf build
 cmake -Bbuild -H.
 cmake --build build
@@ -29,12 +29,12 @@ cmake --build build
 
 Run tests:
 
-```
+```sh
 ./build/test-filter
 ```
 
 Run example:
 
-```
+```sh
 ./build/pedometer logs/HuaweiLong1.log
 ```

--- a/standalone_algorithms/position_estimation/README.md
+++ b/standalone_algorithms/position_estimation/README.md
@@ -29,41 +29,41 @@ After that the last measurements are added into measurements buffer. The size of
 
 Postprocessing of the position is made by position smoother algorithm that is called alpha-beta filter.
 
-In this very low order approximation position `x` is obtained as the time integral of velocity `v`. Assuming that velocity remains approximately constant over the small time interval <img src="https://latex.codecogs.com/svg.image?\Delta&space;T&space;" title="\Delta T " /> between measurements, the position state is projected forward to predict its value at the next sampling time using equation
+In this very low order approximation position `x` is obtained as the time integral of velocity `v`. Assuming that velocity remains approximately constant over the small time interval <img src="https://render.githubusercontent.com/render/math?math=\Delta%20T" title="\Delta T " /> between measurements, the position state is projected forward to predict its value at the next sampling time using equation
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{x_k}&space;=&space;\hat{x_{k-1}}&space;&plus;&space;\Delta&space;T\hat{v_{k-1}}" title="\hat{x_k} = \hat{x_{k-1}} + \Delta T\hat{v_{k-1}}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{x_k}=\hat{x_{k-1}}%2b\Delta%20T\hat{v_{k-1}}" title="\hat{x_k} = \hat{x_{k-1}} + \Delta T\hat{v_{k-1}}" />
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{v_k}&space;\leftarrow&space;\hat{v_{k-1}}" title="\hat{v_k} \leftarrow \hat{v_{k-1}}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{v_k}\leftarrow\hat{v_{k-1}}" title="\hat{v_k} \leftarrow \hat{v_{k-1}}" />
 
 Residual between output measurement and prediction
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{r_k}&space;\leftarrow&space;x_k&space;-&space;\hat{x_k}" title="\hat{r_k} \leftarrow x_k - \hat{x_k}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{r_k}\leftarrow%20x_k-\hat{x_k}" title="\hat{r_k} \leftarrow x_k - \hat{x_k}" />
 
-<img src="https://latex.codecogs.com/svg.image?\alpha&space;\:&space;and&space;\:&space;\beta" title="\alpha \: and \: \beta" /> coefficients are chosen to correct the position estimation
+<img src="https://render.githubusercontent.com/render/math?math=\alpha\:and\:\beta" title="\alpha \: and \: \beta" /> coefficients are chosen to correct the position estimation
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{x_k}&space;\leftarrow&space;\hat{x_k}&space;&plus;&space;\alpha\hat{r_k}" title="\hat{x_k} \leftarrow \hat{x_k} + \alpha\hat{r_k}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{x_k}\leftarrow\hat{x_k}%2b\alpha\hat{r_k}" title="\hat{x_k} \leftarrow \hat{x_k} + \alpha\hat{r_k}" />
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\hat{v_k}&space;\leftarrow&space;\hat{v_k}&space;&plus;&space;\frac{\beta}{\Delta&space;T}\hat{r_k}" title="\hat{v_k} \leftarrow \hat{v_k} + \frac{\beta}{\Delta T}\hat{r_k}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\hat{v_k}\leftarrow\hat{v_k}%2b\frac{\beta}{\Delta%20T}\hat{r_k}" title="\hat{v_k} \leftarrow \hat{v_k} + \frac{\beta}{\Delta T}\hat{r_k}" />
 
-An extra <img src="https://latex.codecogs.com/svg.image?\Delta&space;T&space;" title="\Delta T " /> factor conventionally serves to normalize magnitudes of the multipliers.
+An extra <img src="https://render.githubusercontent.com/render/math?math=\Delta%20T" title="\Delta T " /> factor conventionally serves to normalize magnitudes of the multipliers.
 
 For convergence and stability, the values of the alpha and beta multipliers should be positive and small:
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?0&space;<&space;\alpha&space;<&space;1" title="0 < \alpha < 1" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?0&space;<&space;\beta&space;\leq&space;2" title="0 < \beta \leq 2" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?4&space;-&space;2\alpha&space;-&space;\beta&space;>&space;0" title="4 - 2\alpha - \beta > 0" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=0<\alpha<1" title="0 < \alpha < 1" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=0<\beta\leq2" title="0 < \beta \leq 2" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=4-2\alpha-\beta>0" title="4 - 2\alpha - \beta > 0" />
 
-Initial characteristics of the smoothing are set to zero, coefficient <img src="https://latex.codecogs.com/svg.image?\alpha&space;" title="\alpha " /> is determined by the smoothing coefficient.
+Initial characteristics of the smoothing are set to zero, coefficient <img src="https://render.githubusercontent.com/render/math?math=\alpha" title="\alpha " /> is determined by the smoothing coefficient.
 
 ### Model of signal transferring
 
 Distance between the source of signal and destination can be converted to signal strength
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?P(d)&space;=&space;A&space;-&space;B\log{d^{2}}" title="P(d) = A - B\log{d^{2}}" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?B\log{d^2}&space;=&space;A-P(d)" title="B\log{d^2} = A-P(d)" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?\log{d^2}&space;=&space;\frac{A&space;-&space;P(d)}{B}" title="\log{d^2} = \frac{A - P(d)}{B}" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?d^2&space;=&space;exp\left&space;(&space;\frac{A&space;-&space;P(d)}{B}&space;\right&space;)" title="d^2 = exp\left ( \frac{A - P(d)}{B} \right )" />
-<p align="center"><img src="https://latex.codecogs.com/svg.image?d&space;=&space;\sqrt{exp\left&space;(&space;\frac{A&space;-&space;P(d)}{B}&space;\right&space;)}" title="d = \sqrt{exp\left ( \frac{A - P(d)}{B} \right )}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=P(d)=A-B\log{d^{2}}" title="P(d) = A - B\log{d^{2}}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=B\log{d^2}=A-P(d)" title="B\log{d^2} = A-P(d)" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=\log{d^2}=\frac{A-P(d)}{B}" title="\log{d^2} = \frac{A - P(d)}{B}" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=d^2=\exp\left(\frac{A-P(d)}{B}\right)" title="d^2 = \exp\left ( \frac{A - P(d)}{B} \right )" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=d=\sqrt{\exp\left(\frac{A-P(d)}{B}\right)}" title="d = \sqrt{\exp\left ( \frac{A - P(d)}{B} \right )}" />
 
 ### Results of Position Estimation
 
@@ -75,7 +75,7 @@ Calculated position with precision is written into `output.log` in the folowing 
 
 ### Build
 
-```
+```sh
 cd /standalone_algorithms/position_estimation
 cmake -Bbuild -H.
 cmake --build build
@@ -83,7 +83,7 @@ cmake --build build
 
 Run examples:
 
-```
+```sh
 ./build/position-estimation
 ```
 

--- a/standalone_algorithms/trilateteration/README.md
+++ b/standalone_algorithms/trilateteration/README.md
@@ -32,17 +32,17 @@ However if we get all distances between the mobile and reference nodes, they are
 
 LSE is widely used in the distance based positioning systems. Equation on the mobile location can be set as
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?Y&space;=&space;AX" title="Y = AX" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=Y=AX" title="Y = AX" />
 
 where Y is a known n-dimensional vector, A is NxM matrix. If N>M, the number of equation is greater than the
 number of unknown numbers, we can obtain the optimal X using LSE. The idea of LSE is to make the least value of sum
 of square of error
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?f(x)&space;=&space;(AX&space;-&space;Y)^2&space;=&space;(AX&space;-&space;Y)^{T}(AX&space;-&space;Y)" title="f(x) = (AX - Y)^2 = (AX - Y)^{T}(AX - Y)" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=f(x)=(AX-Y)^2=(AX-Y)^{T}(AX-Y)" title="f(x) = (AX - Y)^2 = (AX - Y)^{T}(AX - Y)" />
 
-We get the minimum of the above function, if <img src="https://latex.codecogs.com/svg.image?A^{T}A" title="A^{T}A" /> is nonsingular
+We get the minimum of the above function, if <img src="https://render.githubusercontent.com/render/math?math=A^{T}A" title="A^{T}A" /> is nonsingular
 
-<p align="center"><img src="https://latex.codecogs.com/svg.image?X&space;=&space;(A^{T}A)^{-1}A^{T}Y" title="X = (A^{T}A)^{-1}A^{T}Y" />
+<p align="center"><img src="https://render.githubusercontent.com/render/math?math=X=(A^{T}A)^{-1}A^{T}Y" title="X = (A^{T}A)^{-1}A^{T}Y" />
 
 ### Trilateration Algorithm
 
@@ -52,7 +52,7 @@ multilateration ranging using more than three signals.
 
 ### Build
 
-```
+```sh
 cd /standalone_algorithms/trilateration
 cmake -Bbuild -H.
 cmake --build build
@@ -60,6 +60,6 @@ cmake --build build
 
 Run tests:
 
-```
+```sh
 ./build/test
 ```


### PR DESCRIPTION
Currently latex.codecogs.com is down returning 503 errors. I thought it would be useful to switch to render.githubusercontent.com because this repo is already hosted on github anyway. I understand if you don't think this is a good reason, especially if codecogs goes back online soon.